### PR TITLE
8366208: Unexpected exception in sun.java2d.cmm.lcms.LCMSImageLayout

### DIFF
--- a/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSImageLayout.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSImageLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,7 +146,9 @@ final class LCMSImageLayout {
     static LCMSImageLayout createImageLayout(BufferedImage image) {
         LCMSImageLayout l = new LCMSImageLayout();
 
-        switch (image.getType()) {
+        Raster raster = image.getRaster();
+        int type = image.getType();
+        switch (type) {
             case BufferedImage.TYPE_INT_RGB:
                 l.pixelType = PT_ARGB_8;
                 l.isIntPacked = true;
@@ -193,7 +195,7 @@ final class LCMSImageLayout {
                         }
                     }
 
-                    return createImageLayout(image.getRaster());
+                    return createImageLayout(raster);
 
                 }
                 return null;
@@ -202,13 +204,15 @@ final class LCMSImageLayout {
         l.width = image.getWidth();
         l.height = image.getHeight();
 
-        switch (image.getType()) {
+        switch (type) {
             case BufferedImage.TYPE_INT_RGB:
             case BufferedImage.TYPE_INT_ARGB:
             case BufferedImage.TYPE_INT_BGR:
                 do {
-                    IntegerComponentRaster intRaster = (IntegerComponentRaster)
-                            image.getRaster();
+                    if (!(raster instanceof IntegerComponentRaster)) {
+                        return null;
+                    }
+                    IntegerComponentRaster intRaster = (IntegerComponentRaster) raster;
                     l.nextRowOffset = safeMult(4, intRaster.getScanlineStride());
                     l.nextPixelOffset = safeMult(4, intRaster.getPixelStride());
                     l.offset = safeMult(4, intRaster.getDataOffset(0));
@@ -225,8 +229,10 @@ final class LCMSImageLayout {
             case BufferedImage.TYPE_3BYTE_BGR:
             case BufferedImage.TYPE_4BYTE_ABGR:
                 do {
-                    ByteComponentRaster byteRaster = (ByteComponentRaster)
-                            image.getRaster();
+                    if (!(raster instanceof ByteComponentRaster)) {
+                        return null;
+                    }
+                    ByteComponentRaster byteRaster = (ByteComponentRaster) raster;
                     l.nextRowOffset = byteRaster.getScanlineStride();
                     l.nextPixelOffset = byteRaster.getPixelStride();
 
@@ -243,8 +249,10 @@ final class LCMSImageLayout {
 
             case BufferedImage.TYPE_BYTE_GRAY:
                 do {
-                    ByteComponentRaster byteRaster = (ByteComponentRaster)
-                            image.getRaster();
+                    if (!(raster instanceof ByteComponentRaster)) {
+                        return null;
+                    }
+                    ByteComponentRaster byteRaster = (ByteComponentRaster) raster;
                     l.nextRowOffset = byteRaster.getScanlineStride();
                     l.nextPixelOffset = byteRaster.getPixelStride();
 
@@ -261,8 +269,10 @@ final class LCMSImageLayout {
 
             case BufferedImage.TYPE_USHORT_GRAY:
                 do {
-                    ShortComponentRaster shortRaster = (ShortComponentRaster)
-                            image.getRaster();
+                    if (!(raster instanceof ShortComponentRaster)) {
+                        return null;
+                    }
+                    ShortComponentRaster shortRaster = (ShortComponentRaster) raster;
                     l.nextRowOffset = safeMult(2, shortRaster.getScanlineStride());
                     l.nextPixelOffset = safeMult(2, shortRaster.getPixelStride());
 

--- a/test/jdk/sun/java2d/cmm/ColorConvertOp/FilterSemiCustomImages.java
+++ b/test/jdk/sun/java2d/cmm/ColorConvertOp/FilterSemiCustomImages.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Point;
+import java.awt.color.ColorSpace;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorConvertOp;
+import java.awt.image.ColorModel;
+import java.awt.image.SampleModel;
+import java.awt.image.WritableRaster;
+import java.io.File;
+
+import javax.imageio.ImageIO;
+
+import static java.awt.image.BufferedImage.TYPE_3BYTE_BGR;
+import static java.awt.image.BufferedImage.TYPE_4BYTE_ABGR;
+import static java.awt.image.BufferedImage.TYPE_4BYTE_ABGR_PRE;
+import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
+import static java.awt.image.BufferedImage.TYPE_INT_ARGB_PRE;
+import static java.awt.image.BufferedImage.TYPE_INT_BGR;
+import static java.awt.image.BufferedImage.TYPE_INT_RGB;
+import static java.awt.image.BufferedImage.TYPE_USHORT_GRAY;
+
+/**
+ * @test
+ * @bug 8366208
+ * @summary Verifies ColorConvertOp works correctly with BufferedImage and
+ *          semi-custom raster
+ */
+public final class FilterSemiCustomImages {
+
+    private static final int W = 144;
+    private static final int H = 123;
+
+    private static final int[] TYPES = {
+            TYPE_INT_RGB, TYPE_INT_ARGB, TYPE_INT_ARGB_PRE, TYPE_INT_BGR,
+            TYPE_3BYTE_BGR, TYPE_4BYTE_ABGR, TYPE_4BYTE_ABGR_PRE,
+            TYPE_USHORT_GRAY
+    };
+
+    private static final int[] CSS = {
+            ColorSpace.CS_CIEXYZ, ColorSpace.CS_GRAY, ColorSpace.CS_LINEAR_RGB,
+            ColorSpace.CS_PYCC, ColorSpace.CS_sRGB
+    };
+
+    private static final class CustomRaster extends WritableRaster {
+        CustomRaster(SampleModel sampleModel, Point origin) {
+            super(sampleModel, origin);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        for (int fromIndex : CSS) {
+            for (int toIndex : CSS) {
+                if (fromIndex != toIndex) {
+                    for (int type : TYPES) {
+                        test(fromIndex, toIndex, type);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void test(int fromIndex, int toIndex, int type)
+            throws Exception
+    {
+        ColorSpace fromCS = ColorSpace.getInstance(fromIndex);
+        ColorSpace toCS = ColorSpace.getInstance(toIndex);
+        ColorConvertOp op = new ColorConvertOp(fromCS, toCS, null);
+
+        // standard source -> standard dst
+        BufferedImage srcGold = new BufferedImage(W, H, type);
+        fill(srcGold);
+        BufferedImage dstGold = new BufferedImage(W, H, type);
+        op.filter(srcGold, dstGold);
+
+        // custom source -> standard dst
+        BufferedImage srcCustom = makeCustomBI(srcGold);
+        fill(srcCustom);
+        BufferedImage dst = new BufferedImage(W, H, type);
+        op.filter(srcCustom, dst);
+        verify(dstGold, dst);
+
+        // standard source -> custom dst
+        BufferedImage src = new BufferedImage(W, H, type);
+        fill(src);
+        BufferedImage dstCustom = makeCustomBI(dstGold);
+        op.filter(src, dstCustom);
+        verify(dstGold, dstCustom);
+
+        // custom source -> custom dst
+        srcCustom = makeCustomBI(srcGold);
+        fill(srcCustom);
+        dstCustom = makeCustomBI(dstGold);
+        op.filter(srcCustom, dstCustom);
+        verify(dstGold, dstCustom);
+    }
+
+    private static BufferedImage makeCustomBI(BufferedImage bi) {
+        ColorModel cm = bi.getColorModel();
+        SampleModel sm = bi.getSampleModel();
+        CustomRaster cr = new CustomRaster(sm, new Point());
+        return new BufferedImage(cm, cr, bi.isAlphaPremultiplied(), null) {
+            @Override
+            public int getType() {
+                return bi.getType();
+            }
+        };
+    }
+
+    private static void fill(BufferedImage image) {
+        int width = image.getWidth();
+        int height = image.getHeight();
+        for (int x = 0; x < width; ++x) {
+            for (int y = 0; y < height; ++y) {
+                // alpha channel may be calculated slightly differently on
+                // different code paths, so only check fully transparent and
+                // fully opaque pixels
+                Color c = new Color(y * 255 / (height - 1),
+                                    x * 255 / (width - 1),
+                                    x % 255,
+                                    (x % 2 == 0) ? 0 : 255);
+                image.setRGB(x, y, c.getRGB());
+            }
+        }
+    }
+
+    private static void verify(BufferedImage dstGold, BufferedImage dst)
+            throws Exception
+    {
+        for (int x = 0; x < W; ++x) {
+            for (int y = 0; y < H; ++y) {
+                if (dst.getRGB(x, y) != dstGold.getRGB(x, y)) {
+                    ImageIO.write(dst, "png", new File("custom.png"));
+                    ImageIO.write(dstGold, "png", new File("gold.png"));
+                    throw new RuntimeException("Test failed.");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [12e6a0b6](https://github.com/openjdk/jdk/commit/12e6a0b6d0086caf156cf5513a604320c619b856) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository. The commit being backported was authored by Sergey Bylokhov on 30 Aug 2025 and was reviewed by Alexey Ivanov and Phil Race.

The backport is not clean: LCMSImageLayout in 17u has four branches that cast the raster instead of three, because TYPE_BYTE_GRAY still has its own branch. The surrounding code is also older, because a long chain of later changes was never backported, so the patch differs in a few other small places.

I decided to stick to this version of the fix, so that the same patch can be used for 11u and 8u without changes.

The test is taken from the original patch without any changes. The jdk_desktop tests are all green.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8366208](https://bugs.openjdk.org/browse/JDK-8366208) needs maintainer approval

### Issue
 * [JDK-8366208](https://bugs.openjdk.org/browse/JDK-8366208): Unexpected exception in sun.java2d.cmm.lcms.LCMSImageLayout (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4637/head:pull/4637` \
`$ git checkout pull/4637`

Update a local copy of the PR: \
`$ git checkout pull/4637` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4637`

View PR using the GUI difftool: \
`$ git pr show -t 4637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4637.diff">https://git.openjdk.org/jdk17u-dev/pull/4637.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4637#issuecomment-5446247781)
</details>
