### PR TITLE
8389648: [TEST_BUG] java/awt/TextField/CaretPositionTest/CaretPositionTest.java fails in OL-9

### DIFF
--- a/test/jdk/java/awt/TextField/CaretPositionTest/CaretPositionTest.java
+++ b/test/jdk/java/awt/TextField/CaretPositionTest/CaretPositionTest.java
@@ -79,13 +79,15 @@ public class CaretPositionTest extends Frame {
 
     public void test() throws AWTException, InterruptedException,
             InvocationTargetException {
-        EventQueue.invokeAndWait(() -> {
-                    onScreen = text_field.getLocationOnScreen();
-                    size = text_field.getSize();
-                });
         Robot robot = new Robot();
         robot.setAutoDelay(50);
         robot.delay(1000);
+
+        EventQueue.invokeAndWait(() -> {
+            onScreen = text_field.getLocationOnScreen();
+            size = text_field.getSize();
+        });
+
         int y = onScreen.y + (size.height / 2);
         robot.mouseMove(onScreen.x + (size.width / 2), y);
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);


### PR DESCRIPTION
Backporting JDK-8389648: [TEST_BUG] java/awt/TextField/CaretPositionTest/CaretPositionTest.java fails in OL-9.

This PR fixes the CaretPositionTest.java test by moving the query of the text field's on-screen location and size to after the robot instantiation and a 1 second delay.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/TextField/CaretPositionTest/CaretPositionTest.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/31555087/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/31555089/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/31555090/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/31555092/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] [JDK-8389648](https://bugs.openjdk.org/browse/JDK-8389648) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389648](https://bugs.openjdk.org/browse/JDK-8389648): [TEST_BUG] java/awt/TextField/CaretPositionTest/CaretPositionTest.java fails in OL-9 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4638/head:pull/4638` \
`$ git checkout pull/4638`

Update a local copy of the PR: \
`$ git checkout pull/4638` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4638`

View PR using the GUI difftool: \
`$ git pr show -t 4638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4638.diff">https://git.openjdk.org/jdk17u-dev/pull/4638.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4638#issuecomment-5452929756)
</details>
