### PR TITLE
8390521: RISC-V: Clean up vector register dispatch in MachSpillCopyNode::implementation

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1544,27 +1544,25 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
     }
   }
 
-  if (bottom_type()->isa_vect() != NULL) {
-    uint ireg = ideal_reg();
-    if (ireg == Op_VecA && cbuf) {
-      C2_MacroAssembler _masm(cbuf);
-      int vector_reg_size_in_bytes = Matcher::scalable_vector_reg_size(T_BYTE);
-      if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
-        // stack to stack
-        __ spill_copy_vector_stack_to_stack(src_offset, dst_offset,
-                                            vector_reg_size_in_bytes);
-      } else if (src_lo_rc == rc_vector && dst_lo_rc == rc_stack) {
-        // vpr to stack
-        __ spill(as_VectorRegister(Matcher::_regEncode[src_lo]), ra_->reg2offset(dst_lo));
-      } else if (src_lo_rc == rc_stack && dst_lo_rc == rc_vector) {
-        // stack to vpr
-        __ unspill(as_VectorRegister(Matcher::_regEncode[dst_lo]), ra_->reg2offset(src_lo));
-      } else if (src_lo_rc == rc_vector && dst_lo_rc == rc_vector) {
-        // vpr to vpr
-        __ vmv1r_v(as_VectorRegister(Matcher::_regEncode[dst_lo]), as_VectorRegister(Matcher::_regEncode[src_lo]));
-      } else {
-        ShouldNotReachHere();
-      }
+  if (bottom_type()->isa_vect() != NULL && cbuf != NULL) {
+    assert(ideal_reg() == Op_VecA, "Must be Op_VecA");
+    C2_MacroAssembler _masm(cbuf);
+    int vector_reg_size_in_bytes = Matcher::scalable_vector_reg_size(T_BYTE);
+    if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
+      // stack to stack
+      __ spill_copy_vector_stack_to_stack(src_offset, dst_offset,
+                                          vector_reg_size_in_bytes);
+    } else if (src_lo_rc == rc_vector && dst_lo_rc == rc_stack) {
+      // vpr to stack
+      __ spill(as_VectorRegister(Matcher::_regEncode[src_lo]), ra_->reg2offset(dst_lo));
+    } else if (src_lo_rc == rc_stack && dst_lo_rc == rc_vector) {
+      // stack to vpr
+      __ unspill(as_VectorRegister(Matcher::_regEncode[dst_lo]), ra_->reg2offset(src_lo));
+    } else if (src_lo_rc == rc_vector && dst_lo_rc == rc_vector) {
+      // vpr to vpr
+      __ vmv1r_v(as_VectorRegister(Matcher::_regEncode[dst_lo]), as_VectorRegister(Matcher::_regEncode[src_lo]));
+    } else {
+      ShouldNotReachHere();
     }
   } else if (cbuf != NULL) {
     C2_MacroAssembler _masm(cbuf);
@@ -1650,12 +1648,8 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
       st->print("%s", Matcher::regName[dst_lo]);
     }
     if (bottom_type()->isa_vect() != NULL) {
-      int vsize = 0;
-      if (ideal_reg() == Op_VecA) {
-        vsize = Matcher::scalable_vector_reg_size(T_BYTE) * 8;
-      } else {
-        ShouldNotReachHere();
-      }
+      assert(ideal_reg() == Op_VecA, "Must be Op_VecA");
+      int vsize = Matcher::scalable_vector_reg_size(T_BYTE) * 8;
       st->print("\t# vector spill size = %d", vsize);
     } else {
       st->print("\t# spill size = %d", is64 ? 64 : 32);


### PR DESCRIPTION
Hi, this patch is a backport of https://github.com/openjdk/jdk/pull/32416

The main purposes of this backport are: 1. to eliminate some unnecessary type checks. 2. With this backport, readability and maintainability are also improved.

### Testing
- [x] `make test TEST="hotspot:tier1 hotspot:tier2 hotspot:tier3"` with fastdebug

This is a risc-v specific change. risk is low.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8390521](https://bugs.openjdk.org/browse/JDK-8390521) needs maintainer approval

### Issue
 * [JDK-8390521](https://bugs.openjdk.org/browse/JDK-8390521): RISC-V: Clean up vector register dispatch in MachSpillCopyNode::implementation (**Enhancement** - P4 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4643/head:pull/4643` \
`$ git checkout pull/4643`

Update a local copy of the PR: \
`$ git checkout pull/4643` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4643`

View PR using the GUI difftool: \
`$ git pr show -t 4643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4643.diff">https://git.openjdk.org/jdk17u-dev/pull/4643.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4643#issuecomment-5521122409)
</details>
